### PR TITLE
Fix for #53, updated zapier env var to match readme

### DIFF
--- a/tests/test_webservice.py
+++ b/tests/test_webservice.py
@@ -104,7 +104,7 @@ def webservice_cli_autorecord(loop, aiohttp_client, monkeypatch):
     monkeypatch.setitem(os.environ, "NEXMO_PRIVATE_KEY_VOICE_APP", MOCK_PRIVATE_KEY)
     monkeypatch.setitem(
         os.environ,
-        "ZAPIER_CATCH_HOOK_RECORDING_FINISHED_URL",
+        "ZAPIER_CATCH_HOOK_RECORDING_URL",
         "https://hooks.zapier.com/1111/2222",
     )
     monkeypatch.setitem(os.environ, "HOTLINE_DESC", MOCK_HOTLINE_DESC)

--- a/webservice/__main__.py
+++ b/webservice/__main__.py
@@ -101,7 +101,7 @@ async def answer_call(request):
             {
                 "record": True,
                 "eventUrl": [
-                    os.environ.get("ZAPIER_CATCH_HOOK_RECORDING_FINISHED_URL")
+                    os.environ.get("ZAPIER_CATCH_HOOK_RECORDING_URL")
                 ],
             }
         )


### PR DESCRIPTION
There's a mismatch between the environment variable referenced in the README and the one used in the code. If `AUTO_RECORD` has been set to `True` but the wrong environment variable is used, it leads to the behavior described in #53, without any recordings being generated. This PR resolves that mismatch.